### PR TITLE
chore: do not attempt to major bump devDependencies

### DIFF
--- a/recommended.json
+++ b/recommended.json
@@ -73,17 +73,15 @@
       "automergeType": "branch"
     },
     {
-      "matchUpdateTypes": ["major"],
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
-    },
-    {
       "matchSourceUrlPrefixes": [
         "https://github.com/bpmn-io/",
         "https://github.com/zeebe-io/",
         "https://github.com/camunda/"
       ],
-      "schedule": "at any time"
+      "matchUpdateTypes": ["minor", "patch", "bump", "pin", "major"],
+      "schedule": "at any time",
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Trying to decrease the upgrading noise.

Related to `renovate` mini-retro (2022-11-09).