### PR TITLE
chore: remove reviewer assignment

### DIFF
--- a/recommended.json
+++ b/recommended.json
@@ -6,9 +6,6 @@
     ":disableDependencyDashboard"
   ],
   "labels": ["dependencies"],
-  "reviewers": [
-    "team:modeling-dev"
-  ],
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
this should be handled by the community worker. This ensures that the noise is kept lower for all team members, as a single dependency often fails in multiple repos, effectively pinging everyone with round-robin assignment

related to https://github.com/bpmn-io/internal-docs/issues/713

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
