### PR TITLE
feat: configure vulnerability alerts

### DIFF
--- a/recommended.json
+++ b/recommended.json
@@ -97,5 +97,9 @@
     }
   ],
   "semanticCommitScope": null,
-  "schedule": ["after 10pm and before 5:00am"]
+  "schedule": ["after 10pm and before 5:00am"],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true
+  }
 }


### PR DESCRIPTION
I'd like to try out renovate for fixing the vulnerability alerts. Since the dependabot alerts are enabled for the entire bpmn-io organization, we should expect quite a lot of PRs soon. Still, if most of them are automergable, the updates should be applied automatically.