### PR TITLE
chore: re-use the same base in security-only

### DIFF
--- a/security-only.json
+++ b/security-only.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": [
+    "config:js-lib",
+    ":preserveSemverRanges",
+    ":disableDependencyDashboard"
+  ],
   "packageRules": [
     {
       "enabled": false,


### PR DESCRIPTION
This is to disable the dependency dashboard.