### PR TITLE
fix: use correct source url pattern

### DIFF
--- a/recommended.json
+++ b/recommended.json
@@ -72,10 +72,9 @@
       "automergeSchedule": "after 10pm and before 5:00am"
     },
     {
-      "matchSourceUrlPrefixes": [
-        "https://github.com/bpmn-io/",
-        "https://github.com/zeebe-io/",
-        "https://github.com/camunda/"
+      "matchSourceUrls": [
+        "https://github.com/bpmn-io/*",
+        "https://github.com/camunda/*"
       ],
       "matchUpdateTypes": ["minor", "patch", "bump", "pin"],
       "schedule": "at any time",


### PR DESCRIPTION
Outdated `zeebe-io` org is removed, and patterns use glob now.

### Proposed Changes

Cf. https://docs.renovatebot.com/string-pattern-matching/

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
